### PR TITLE
Introduce MemoryProf for detecting memory spikes

### DIFF
--- a/docs/profilers/memory_prof.md
+++ b/docs/profilers/memory_prof.md
@@ -1,0 +1,85 @@
+# MemoryProf
+
+MemoryProf tracks memory usage during your test suite run, and can help to detect test examples and groups that cause memory spikes. Memory profiling supports two metrics: RSS and allocations.
+
+Example output:
+
+```sh
+[TEST PROF INFO] MemoryProf results
+
+Final RSS: 673KB
+
+Top 5 groups (by RSS):
+
+AnswersController (./spec/controllers/answers_controller_spec.rb:3) – +80KB (13.50%)
+QuestionsController (./spec/controllers/questions_controller_spec.rb:3) – +32KB  (9.08%)
+CommentsController (./spec/controllers/comments_controller_spec.rb:3) – +16KB (3.27%)
+
+Top 5 examples (by RSS):
+
+destroys question (./spec/controllers/questions_controller_spec.rb:38) – +144KB (24.38%)
+change comments count (./spec/controllers/comments_controller_spec.rb:7) – +120KB (20.00%)
+change Votes count (./spec/shared_examples/controllers/voted_examples.rb:23) – +90KB (16.36%)
+change Votes count (./spec/shared_examples/controllers/voted_examples.rb:23) – +64KB (12.86%)
+fails (./spec/shared_examples/controllers/invalid_examples.rb:3) – +32KB (5.00%)
+```
+
+The examples block shows the amount of memory used by each example, and the groups block displays the memory allocated by other code defined in the groups. For example, RSpec groups may include heavy `before(:all)` (or `before_all`) setup blocks, so it is helpful to see which groups use the most amount of memory outside of their examples.
+
+## Instructions
+
+To activate MemoryProf with:
+
+### RSpec
+
+Use `TEST_MEM_PROF` environment variable to set which metric to use:
+
+```sh
+TEST_MEM_PROF='rss' rspec ...
+TEST_MEM_PROF='alloc' rake rspec ...
+```
+
+### Minitest
+
+Use `TEST_MEM_PROF` environment variable to set which metric to use:
+
+```sh
+TEST_MEM_PROF='rss' rake test
+TEST_MEM_PROF='alloc' rspec ...
+```
+
+or use CLI options as well:
+
+```sh
+# Run a specific file using CLI option
+ruby test/my_super_test.rb --mem-prof=rss
+
+# Show the list of possible options:
+ruby test/my_super_test.rb --help
+```
+
+## Configuration
+
+By default, MemoryProf tracks the top 5 examples and groups that use the largest amount of memory.
+You can set how many examples/groups to display with the option:
+
+```sh
+TEST_MEM_PROF='rss' TEST_MEM_PROF_COUNT=10 rspec ...
+```
+
+or with CLI options for Minitest:
+
+```sh
+# Run a specific file using CLI option
+ruby test/my_super_test.rb --mem-prof=rs --mem-prof-top-count=10
+```
+
+## Supported Ruby Engines & OS
+
+Currently the allocation mode is not supported for JRuby.
+
+Since RSS depends on the OS, MemoryProf uses different tools to retrieve it:
+
+* Linux – `/proc/$pid/statm` file,
+* macOS, Solaris, BSD – `ps`,
+* Windows – `Get-Process`, requires PowerShell to be installed.

--- a/lib/minitest/test_prof_plugin.rb
+++ b/lib/minitest/test_prof_plugin.rb
@@ -2,6 +2,7 @@
 
 require "test_prof/event_prof/minitest"
 require "test_prof/factory_doctor/minitest"
+require "test_prof/memory_prof/minitest"
 
 module Minitest # :nodoc:
   module TestProf # :nodoc:
@@ -13,6 +14,8 @@ module Minitest # :nodoc:
         opts[:per_example] = true if ENV["EVENT_PROF_EXAMPLES"]
         opts[:fdoc] = true if ENV["FDOC"]
         opts[:sample] = true if ENV["SAMPLE"] || ENV["SAMPLE_GROUPS"]
+        opts[:mem_prof_mode] = ENV["TEST_MEM_PROF"] if ENV["TEST_MEM_PROF"]
+        opts[:mem_prof_top_count] = ENV["TEST_MEM_PROF_COUNT"] if ENV["TEST_MEM_PROF_COUNT"]
       end
     end
   end
@@ -33,6 +36,12 @@ module Minitest # :nodoc:
     opts.on "--factory-doctor", TrueClass, "Enable Factory Doctor for your examples" do |flag|
       options[:fdoc] = flag
     end
+    opts.on "--mem-prof=MODE", "Enable MemoryProf for your examples" do |flag|
+      options[:mem_prof_mode] = flag
+    end
+    opts.on "--mem-prof-top-count=N", "Limits MemoryProf results with N groups/examples" do |flag|
+      options[:mem_prof_top_count] = flag
+    end
   end
 
   def self.plugin_test_prof_init(options)
@@ -40,6 +49,7 @@ module Minitest # :nodoc:
 
     reporter << TestProf::EventProfReporter.new(options[:io], options) if options[:event]
     reporter << TestProf::FactoryDoctorReporter.new(options[:io], options) if options[:fdoc]
+    reporter << TestProf::MemoryProfReporter.new(options[:io], options) if options[:mem_prof_mode]
 
     ::TestProf::MinitestSample.call if options[:sample]
   end

--- a/lib/test_prof.rb
+++ b/lib/test_prof.rb
@@ -8,6 +8,7 @@ require "test_prof/stack_prof"
 require "test_prof/event_prof"
 require "test_prof/factory_doctor"
 require "test_prof/factory_prof"
+require "test_prof/memory_prof"
 require "test_prof/rspec_stamp"
 require "test_prof/tag_prof"
 require "test_prof/rspec_dissect" if TestProf.rspec?

--- a/lib/test_prof/memory_prof.rb
+++ b/lib/test_prof/memory_prof.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_prof/memory_prof/tracker"
+require "test_prof/memory_prof/printer"
+
+module TestProf
+  # MemoryProf can help in detecting test examples causing memory spikes.
+  # It supports two metrics: RSS and allocations.
+  #
+  # Example:
+  #
+  #   TEST_MEM_PROF='rss' rspec ...
+  #   TEST_MEM_PROF='alloc' rspec ...
+  #
+  # By default MemoryProf shows the top 5 examples and groups (for RSpec) but you can
+  # set how many items to display with `TEST_MEM_PROF_COUNT`:
+  #
+  #   TEST_MEM_PROF='rss' TEST_MEM_PROF_COUNT=10 rspec ...
+  #
+  # The examples block shows the amount of memory used by each example, and the groups
+  # block displays the memory allocated by other code defined in the groups. For example,
+  # RSpec groups may include heavy `before(:all)` (or `before_all`) setup blocks, so it is
+  # helpful to see which groups use the most amount of memory outside of their examples.
+
+  module MemoryProf
+    # MemoryProf configuration
+    class Configuration
+      attr_reader :mode, :top_count
+
+      def initialize
+        self.mode = ENV["TEST_MEM_PROF"]
+        self.top_count = ENV["TEST_MEM_PROF_COUNT"]
+      end
+
+      def mode=(value)
+        @mode = (value == "alloc") ? :alloc : :rss
+      end
+
+      def top_count=(value)
+        @top_count = value.to_i
+        @top_count = 5 unless @top_count.positive?
+      end
+    end
+
+    class << self
+      TRACKERS = {
+        alloc: AllocTracker,
+        rss: RssTracker
+      }.freeze
+
+      PRINTERS = {
+        alloc: AllocPrinter,
+        rss: RssPrinter
+      }.freeze
+
+      def config
+        @config ||= Configuration.new
+      end
+
+      def configure
+        yield config
+      end
+
+      def tracker
+        tracker = TRACKERS[config.mode]
+        tracker.new(config.top_count)
+      end
+
+      def printer(tracker)
+        printer = PRINTERS[config.mode]
+        printer.new(tracker)
+      end
+    end
+  end
+end
+
+require "test_prof/memory_prof/rspec" if TestProf.rspec?
+require "test_prof/memory_prof/minitest" if TestProf.minitest?

--- a/lib/test_prof/memory_prof/minitest.rb
+++ b/lib/test_prof/memory_prof/minitest.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "minitest/base_reporter"
+
+module Minitest
+  module TestProf
+    class MemoryProfReporter < BaseReporter # :nodoc:
+      attr_reader :tracker, :printer, :current_example
+
+      def initialize(io = $stdout, options = {})
+        super
+
+        configure_profiler(options)
+
+        @tracker = ::TestProf::MemoryProf.tracker
+        @printer = ::TestProf::MemoryProf.printer(tracker)
+
+        @current_example = nil
+      end
+
+      def prerecord(group, example)
+        set_current_example(group, example)
+        tracker.example_started(current_example)
+      end
+
+      def record(example)
+        tracker.example_finished(current_example)
+      end
+
+      def start
+        tracker.start
+      end
+
+      def report
+        tracker.finish
+        printer.print
+      end
+
+      private
+
+      def set_current_example(group, example)
+        @current_example = {
+          name: example.gsub(/^test_(?:\d+_)?/, ""),
+          location: location_with_line_number(group, example)
+        }
+      end
+
+      def configure_profiler(options)
+        ::TestProf::MemoryProf.configure do |config|
+          config.mode = options[:mem_prof_mode]
+          config.top_count = options[:mem_prof_top_count] if options[:mem_prof_top_count]
+        end
+      end
+    end
+  end
+end

--- a/lib/test_prof/memory_prof/printer.rb
+++ b/lib/test_prof/memory_prof/printer.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_prof/memory_prof/printer/number_to_human"
+require "test_prof/ext/string_truncate"
+
+module TestProf
+  module MemoryProf
+    class Printer
+      include Logging
+      using StringTruncate
+
+      def initialize(tracker)
+        @tracker = tracker
+      end
+
+      def print
+        messages = [
+          "MemoryProf results\n\n",
+          print_total,
+          print_block("groups", tracker.groups),
+          print_block("examples", tracker.examples)
+        ]
+
+        log :info, messages.join
+      end
+
+      private
+
+      attr_reader :tracker
+
+      def print_block(name, items)
+        return if items.empty?
+
+        <<~GROUP
+          Top #{tracker.top_count} #{name} (by #{mode}):
+
+          #{print_items(items)}
+        GROUP
+      end
+
+      def print_items(items)
+        messages =
+          items.map do |item|
+            <<~ITEM
+              #{item[:name].truncate(30)} (#{item[:location]}) – +#{memory_amount(item)} (#{memory_percentage(item)}%)
+            ITEM
+          end
+
+        messages.join
+      end
+
+      def memory_percentage(item)
+        (100.0 * item[:memory] / tracker.total_memory).round(2)
+      end
+
+      def number_to_human(value)
+        NumberToHuman.convert(value)
+      end
+    end
+
+    class AllocPrinter < Printer
+      private
+
+      def mode
+        "allocations"
+      end
+
+      def print_total
+        "Total allocations: #{tracker.total_memory}\n\n"
+      end
+
+      def memory_amount(item)
+        item[:memory]
+      end
+    end
+
+    class RssPrinter < Printer
+      private
+
+      def mode
+        "RSS"
+      end
+
+      def print_total
+        "Final RSS: #{number_to_human(tracker.total_memory)}\n\n"
+      end
+
+      def memory_amount(item)
+        number_to_human(item[:memory])
+      end
+    end
+  end
+end

--- a/lib/test_prof/memory_prof/printer/number_to_human.rb
+++ b/lib/test_prof/memory_prof/printer/number_to_human.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module TestProf
+  module MemoryProf
+    class Printer
+      module NumberToHuman
+        BASE = 1024
+        UNITS = %w[B KB MB GB TB PB EB ZB]
+
+        class << self
+          def convert(number)
+            exponent = exponent(number)
+            human_size = number.to_f / (BASE**exponent)
+
+            "#{round(human_size)}#{UNITS[exponent]}"
+          end
+
+          private
+
+          def exponent(number)
+            return 0 if number.zero?
+
+            max = UNITS.size - 1
+
+            exponent = (Math.log(number) / Math.log(BASE)).to_i
+            (exponent > max) ? max : exponent
+          end
+
+          def round(number)
+            if integer?(number)
+              number.round
+            else
+              number.round(2)
+            end
+          end
+
+          def integer?(number)
+            number.round == number
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/test_prof/memory_prof/rspec.rb
+++ b/lib/test_prof/memory_prof/rspec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module TestProf
+  module MemoryProf
+    class RSpecListener
+      NOTIFICATIONS = %i[
+        example_started
+        example_finished
+        example_group_started
+        example_group_finished
+      ].freeze
+
+      attr_reader :tracker, :printer
+
+      def initialize
+        @tracker = MemoryProf.tracker
+        @printer = MemoryProf.printer(tracker)
+
+        @tracker.start
+      end
+
+      def example_started(notification)
+        tracker.example_started(example(notification))
+      end
+
+      def example_finished(notification)
+        tracker.example_finished(example(notification))
+      end
+
+      def example_group_started(notification)
+        tracker.group_started(group(notification))
+      end
+
+      def example_group_finished(notification)
+        tracker.group_finished(group(notification))
+      end
+
+      def report
+        tracker.finish
+        printer.print
+      end
+
+      private
+
+      def example(notification)
+        {
+          name: notification.example.description,
+          location: notification.example.metadata[:location]
+        }
+      end
+
+      def group(notification)
+        {
+          name: notification.group.description,
+          location: notification.group.metadata[:location]
+        }
+      end
+    end
+  end
+end
+
+TestProf.activate("TEST_MEM_PROF") do
+  RSpec.configure do |config|
+    listener = nil
+
+    config.before(:suite) do
+      listener = TestProf::MemoryProf::RSpecListener.new
+
+      config.reporter.register_listener(
+        listener, *TestProf::MemoryProf::RSpecListener::NOTIFICATIONS
+      )
+    end
+
+    config.after(:suite) { listener&.report }
+  end
+end

--- a/lib/test_prof/memory_prof/tracker.rb
+++ b/lib/test_prof/memory_prof/tracker.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_prof/memory_prof/tracker/linked_list"
+require "test_prof/memory_prof/tracker/rss_tool"
+
+module TestProf
+  module MemoryProf
+    # Tracker is responsible for tracking memory usage and determining
+    # the top n examples and groups. There are two types of trackers:
+    # AllocTracker and RssTracker.
+    #
+    # A tracker consists of four main parts:
+    #  * list - a linked list that is being used to track memmory for individual groups/examples.
+    #    list is an instance of LinkedList (for more info see tracker/linked_list.rb)
+    #  * examples – the top n examples, an instance of Utils::SizedOrderedSet.
+    #  * groups – the top n groups, an instance of Utils::SizedOrderedSet.
+    #  * track - a method that fetches the amount of memory in use at a certain point.
+    class Tracker
+      attr_reader :top_count, :examples, :groups, :total_memory, :list
+
+      def initialize(top_count)
+        raise "Your Ruby Engine or OS is not supported" unless supported?
+
+        @top_count = top_count
+
+        @examples = Utils::SizedOrderedSet.new(top_count, sort_by: :memory)
+        @groups = Utils::SizedOrderedSet.new(top_count, sort_by: :memory)
+      end
+
+      def start
+        @list = LinkedList.new(track)
+      end
+
+      def finish
+        node = list.remove_node(:total, track)
+        @total_memory = node.total_memory
+      end
+
+      def example_started(example)
+        list.add_node(example, track)
+      end
+
+      def example_finished(example)
+        node = list.remove_node(example, track)
+        examples << {**example, memory: node.total_memory}
+      end
+
+      def group_started(group)
+        list.add_node(group, track)
+      end
+
+      def group_finished(group)
+        node = list.remove_node(group, track)
+        groups << {**group, memory: node.hooks_memory}
+      end
+    end
+
+    class AllocTracker < Tracker
+      def track
+        GC.stat[:total_allocated_objects]
+      end
+
+      def supported?
+        RUBY_ENGINE != "jruby"
+      end
+    end
+
+    class RssTracker < Tracker
+      def initialize(top_count)
+        @rss_tool = RssTool.tool
+
+        super
+      end
+
+      def track
+        @rss_tool.track
+      end
+
+      def supported?
+        !!@rss_tool
+      end
+    end
+  end
+end

--- a/lib/test_prof/memory_prof/tracker/linked_list.rb
+++ b/lib/test_prof/memory_prof/tracker/linked_list.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module TestProf
+  module MemoryProf
+    class Tracker
+      # LinkedList is a linked list that track memory usage for individual examples/groups.
+      # A list node (`LinkedListNode`) represents an example/group and its memory usage info:
+      #
+      # * memory_at_start - the amount of memory at the start of an example/group
+      # * memory_at_finish - the amount of memory at the end of an example/group
+      # * nested_memory - the amount of memory allocated by examples/groups defined inside a group
+      # * previous - a link to the previous node
+      #
+      # Each node has a link to its previous node, and the head node points to the current example/group.
+      # If we picture a linked list as a tree with root being the top level group and leaves being
+      # current examples/groups, then the head node will always point to a leaf in that tree.
+      #
+      # For example, if we have the following spec:
+      #
+      #   describe Question do
+      #     decribe "#publish" do
+      #       context "when not published" do
+      #         it "makes the question visible" do
+      #           ...
+      #         end
+      #       end
+      #     end
+      #   end
+      #
+      # At the moment when rspec is executing the example, the list has the following structure
+      # (^ denotes the head node):
+      #
+      #    ^"makes the question visible" ->  "when not published" -> "#publish" -> Question
+      #
+      # LinkedList supports two method for working with it:
+      #
+      #  * add_node – adds a node to the beginig of the list. At this point an example or group
+      #    has started and we track how much memory has already been used.
+      #  * remove_node – removes and returns the head node from the list. It means that the node
+      #    example/group has finished and it is time to calculate its memory usage.
+      #
+      # When we remove a node we add its total_memory to the previous node.nested_memory, thus
+      # gradually tracking the amount of memory used by nested examples inside a group.
+      #
+      # In the example above, after we remove the node "makes the question visible", we add its total
+      # memory usage to nested_memory of the "when not published" node. If the "when not published"
+      # group contains other examples or sub-groups, their total_memory will also be added to
+      # "when not published" nested_memory. So when the group finishes we will have the total amount
+      # of memory used by its nested examples/groups, and thus we will be able to calculate the memory
+      # used by hooks and other code inside a group by subtracting nested_memory from total_memory.
+      class LinkedList
+        attr_reader :head
+
+        def initialize(memory_at_start)
+          add_node(:total, memory_at_start)
+        end
+
+        def add_node(item, memory_at_start)
+          @head = LinkedListNode.new(
+            item: item,
+            previous: head,
+            memory_at_start: memory_at_start
+          )
+        end
+
+        def remove_node(item, memory_at_finish)
+          return if head.item != item
+          head.finish(memory_at_finish)
+
+          current = head
+          @head = head.previous
+
+          current
+        end
+      end
+
+      class LinkedListNode
+        attr_reader :item, :previous, :memory_at_start, :memory_at_finish, :nested_memory
+
+        def initialize(item:, memory_at_start:, previous:)
+          @item = item
+          @previous = previous
+
+          @memory_at_start = memory_at_start || 0
+          @memory_at_finish = nil
+          @nested_memory = 0
+        end
+
+        def total_memory
+          return 0 if memory_at_finish.nil?
+          # It seems that on Windows Minitest may release a lot of memory to
+          # the OS when it finishes and executes #report, leading to memory_at_finish
+          # being less than memory_at_start. In this case we return nested_memory
+          # which does not account for the memory used in `after` hooks, but it
+          # is better than nothing.
+          return nested_memory if memory_at_start > memory_at_finish
+
+          memory_at_finish - memory_at_start
+        end
+
+        def hooks_memory
+          total_memory - nested_memory
+        end
+
+        def finish(memory_at_finish)
+          @memory_at_finish = memory_at_finish
+
+          previous&.add_nested(self)
+        end
+
+        protected
+
+        def add_nested(node)
+          @nested_memory += node.total_memory
+        end
+      end
+    end
+  end
+end

--- a/lib/test_prof/memory_prof/tracker/rss_tool.rb
+++ b/lib/test_prof/memory_prof/tracker/rss_tool.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+module TestProf
+  module MemoryProf
+    class Tracker
+      module RssTool
+        class ProcFS
+          def initialize
+            @statm = File.open("/proc/#{$$}/statm", "r")
+            @page_size = get_page_size
+          end
+
+          def track
+            @statm.seek(0)
+            @statm.gets.split(/\s/)[1].to_i * @page_size
+          end
+
+          private
+
+          def get_page_size
+            [
+              -> {
+                require "etc"
+                Etc.sysconf(Etc::SC_PAGE_SIZE)
+              },
+              -> { `getconf PAGE_SIZE`.to_i },
+              -> { 0x1000 }
+            ].each do |strategy|
+              page_size = begin
+                strategy.call
+              rescue
+                next
+              end
+              return page_size
+            end
+          end
+        end
+
+        class PS
+          def track
+            `ps -o rss -p #{$$}`.strip.split.last.to_i * 1024
+          end
+        end
+
+        class GetProcess
+          def track
+            command.strip.split.last.to_i
+          end
+
+          private
+
+          def command
+            `powershell -Command "Get-Process -Id #{$$} | select WS"`
+          end
+        end
+
+        TOOLS = {
+          linux: ProcFS,
+          macosx: PS,
+          unix: PS,
+          windows: GetProcess
+        }.freeze
+
+        class << self
+          def tool
+            TOOLS[os_type]&.new
+          end
+
+          def os_type
+            case RbConfig::CONFIG["host_os"]
+            when /linux/
+              :linux
+            when /darwin|mac os/
+              :macosx
+            when /solaris|bsd/
+              :unix
+            when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+              :windows
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/test_prof/utils/sized_ordered_set.rb
+++ b/lib/test_prof/utils/sized_ordered_set.rb
@@ -53,6 +53,10 @@ module TestProf
         data.size
       end
 
+      def empty?
+        size.zero?
+      end
+
       def to_a
         data.dup
       end

--- a/spec/integrations/fixtures/minitest/memory_prof_fixture.rb
+++ b/spec/integrations/fixtures/minitest/memory_prof_fixture.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "test-prof"
+require "securerandom"
+
+describe "First Allocations" do
+  it "allocates 500 objects" do
+    500.times.map { SecureRandom.hex }
+  end
+
+  it "allocates 1000 objects" do
+    1000.times.map { SecureRandom.hex }
+  end
+
+  it "allocates 10_000 objects" do
+    10_000.times.map { SecureRandom.hex }
+  end
+end
+
+describe "Second Allocations" do
+  it "allocates nothing" do
+  end
+
+  it "allocates 100 objects" do
+    100.times.map { SecureRandom.hex }
+  end
+end

--- a/spec/integrations/fixtures/rspec/memory_prof_fixture.rb
+++ b/spec/integrations/fixtures/rspec/memory_prof_fixture.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test-prof"
+require "securerandom"
+
+describe "Examples allocations" do
+  it "allocates 500 objects" do
+    500.times.map { SecureRandom.hex }
+  end
+
+  it "allocates 1000 objects" do
+    1000.times.map { SecureRandom.hex }
+  end
+
+  it "allocates 10_000 objects" do
+    10_000.times.map { SecureRandom.hex }
+  end
+end
+
+describe "Groups Allocations" do
+  context "with 500 allocations" do
+    before(:context) do
+      @array = 500.times.map { SecureRandom.hex }
+    end
+
+    it "does not allocate anything" do
+    end
+  end
+
+  context "with 1000 allocations" do
+    before(:context) do
+      @array = 1000.times.map { SecureRandom.hex }
+    end
+
+    it "does not allocate anything" do
+    end
+  end
+
+  context "with 10_000 allocations" do
+    before(:context) do
+      @array = 10_000.times.map { SecureRandom.hex }
+    end
+
+    it "does not allocate anything" do
+    end
+  end
+end

--- a/spec/integrations/memory_prof_minitest_spec.rb
+++ b/spec/integrations/memory_prof_minitest_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+number_regex = /\d+\.?\d{0,2}/
+memory_human_regex = /#{number_regex}[KMGTPEZ]?B/
+percent_regex = /#{number_regex}%/
+
+describe "MemoryProf Minitest" do
+  specify "with default options", :aggregate_failures do
+    output = run_minitest("memory_prof", env: {"TEST_MEM_PROF" => "test"})
+
+    expect(output).to include("MemoryProf results")
+    expect(output).to match(/Final RSS: #{memory_human_regex}/)
+
+    expect(output).to include("Top 5 examples (by RSS):")
+
+    expect(output).to match(/allocates 10_000 objects \(\.\/memory_prof_fixture.rb:16\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 1000 objects \(\.\/memory_prof_fixture.rb:12\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 500 objects \(\.\/memory_prof_fixture.rb:8\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 100 objects \(\.\/memory_prof_fixture.rb:25\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates nothing \(\.\/memory_prof_fixture.rb:22\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+  end
+
+  specify "in RSS mode", :aggregate_failures do
+    output = run_minitest("memory_prof", env: {"TEST_MEM_PROF" => "rss"})
+
+    expect(output).to include("MemoryProf results")
+    expect(output).to match(/Final RSS: #{memory_human_regex}/)
+
+    expect(output).to include("Top 5 examples (by RSS):")
+
+    expect(output).to match(/allocates 10_000 objects \(\.\/memory_prof_fixture.rb:16\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 1000 objects \(\.\/memory_prof_fixture.rb:12\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 500 objects \(\.\/memory_prof_fixture.rb:8\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 100 objects \(\.\/memory_prof_fixture.rb:25\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates nothing \(\.\/memory_prof_fixture.rb:22\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+  end
+
+  if RUBY_ENGINE != "jruby"
+    specify "in allocations mode", :aggregate_failures do
+      output = run_minitest("memory_prof", env: {"TEST_MEM_PROF" => "alloc"})
+
+      expect(output).to include("MemoryProf results")
+      expect(output).to match(/Total allocations: #{number_regex}/)
+
+      expect(output).to include("Top 5 examples (by allocations):")
+
+      expect(output).to match(/allocates 10_000 objects \(\.\/memory_prof_fixture.rb:16\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/allocates 1000 objects \(\.\/memory_prof_fixture.rb:12\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/allocates 500 objects \(\.\/memory_prof_fixture.rb:8\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/allocates 100 objects \(\.\/memory_prof_fixture.rb:25\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/allocates nothing \(\.\/memory_prof_fixture.rb:22\) – \+#{number_regex} \(#{percent_regex}\)/)
+    end
+  end
+
+  specify "with top_count", :aggregate_failures do
+    output = run_minitest("memory_prof", env: {"TEST_MEM_PROF" => "rss", "TEST_MEM_PROF_COUNT" => "3"})
+
+    expect(output).to include("MemoryProf results")
+    expect(output).to match(/Final RSS: #{memory_human_regex}/)
+
+    expect(output).to include("Top 3 examples (by RSS):")
+  end
+end

--- a/spec/integrations/memory_prof_rspec_spec.rb
+++ b/spec/integrations/memory_prof_rspec_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+number_regex = /\d+\.?\d{0,2}/
+memory_human_regex = /#{number_regex}[KMGTPEZ]?B/
+percent_regex = /#{number_regex}%/
+
+describe "MemoryProf RSpec" do
+  specify "with default options", :aggregate_failures do
+    output = run_rspec("memory_prof", env: {"TEST_MEM_PROF" => "test"})
+
+    expect(output).to include("MemoryProf results")
+    expect(output).to match(/Final RSS: #{memory_human_regex}/)
+
+    expect(output).to include("Top 5 groups (by RSS):")
+    expect(output).to include("Top 5 examples (by RSS):")
+
+    expect(output).to match(/with 10_000 allocations \(\.\/memory_prof_fixture.rb:39\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/with 1000 allocations \(\.\/memory_prof_fixture.rb:30\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/with 500 allocations \(\.\/memory_prof_fixture.rb:21\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/Groups Allocations \(\.\/memory_prof_fixture.rb:20\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/Examples allocations \(\.\/memory_prof_fixture.rb:6\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+
+    expect(output).to match(/allocates 10_000 objects \(\.\/memory_prof_fixture.rb:15\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 1000 objects \(\.\/memory_prof_fixture.rb:11\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 500 objects \(\.\/memory_prof_fixture.rb:7\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+  end
+
+  specify "in RSS mode", :aggregate_failures do
+    output = run_rspec("memory_prof", env: {"TEST_MEM_PROF" => "rss"})
+
+    expect(output).to include("MemoryProf results")
+    expect(output).to match(/Final RSS: #{memory_human_regex}/)
+
+    expect(output).to include("Top 5 groups (by RSS):")
+    expect(output).to include("Top 5 examples (by RSS):")
+
+    expect(output).to match(/with 10_000 allocations \(\.\/memory_prof_fixture.rb:39\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/with 1000 allocations \(\.\/memory_prof_fixture.rb:30\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/with 500 allocations \(\.\/memory_prof_fixture.rb:21\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/Groups Allocations \(\.\/memory_prof_fixture.rb:20\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/Examples allocations \(\.\/memory_prof_fixture.rb:6\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+
+    expect(output).to match(/allocates 10_000 objects \(\.\/memory_prof_fixture.rb:15\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 1000 objects \(\.\/memory_prof_fixture.rb:11\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+    expect(output).to match(/allocates 500 objects \(\.\/memory_prof_fixture.rb:7\) – \+#{memory_human_regex} \(#{percent_regex}\)/)
+  end
+
+  if RUBY_ENGINE != "jruby"
+    specify "in allocations mode", :aggregate_failures do
+      output = run_rspec("memory_prof", env: {"TEST_MEM_PROF" => "alloc"})
+
+      expect(output).to include("MemoryProf results")
+      expect(output).to match(/Total allocations: #{number_regex}/)
+
+      expect(output).to include("Top 5 groups (by allocations):")
+      expect(output).to include("Top 5 examples (by allocations):")
+
+      expect(output).to match(/with 10_000 allocations \(\.\/memory_prof_fixture.rb:39\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/with 1000 allocations \(\.\/memory_prof_fixture.rb:30\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/with 500 allocations \(\.\/memory_prof_fixture.rb:21\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/Groups Allocations \(\.\/memory_prof_fixture.rb:20\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/Examples allocations \(\.\/memory_prof_fixture.rb:6\) – \+#{number_regex} \(#{percent_regex}\)/)
+
+      expect(output).to match(/allocates 10_000 objects \(\.\/memory_prof_fixture.rb:15\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/allocates 1000 objects \(\.\/memory_prof_fixture.rb:11\) – \+#{number_regex} \(#{percent_regex}\)/)
+      expect(output).to match(/allocates 500 objects \(\.\/memory_prof_fixture.rb:7\) – \+#{number_regex} \(#{percent_regex}\)/)
+    end
+  end
+
+  specify "with top_count", :aggregate_failures do
+    output = run_rspec("memory_prof", env: {"TEST_MEM_PROF" => "rss", "TEST_MEM_PROF_COUNT" => "3"})
+
+    expect(output).to include("MemoryProf results")
+    expect(output).to match(/Final RSS: #{memory_human_regex}/)
+
+    expect(output).to include("Top 3 groups (by RSS):")
+    expect(output).to include("Top 3 examples (by RSS):")
+  end
+end

--- a/spec/test_prof/before_all/adapters/active_record_spec.rb
+++ b/spec/test_prof/before_all/adapters/active_record_spec.rb
@@ -35,7 +35,7 @@ describe TestProf::BeforeAll::Adapters::ActiveRecord do
 
         it "warns when connection does not have open transaction" do
           expect { subject }.to output(
-            "!!! before_all transaction has been already rollbacked and could work incorrectly\n"
+            /!!! before_all transaction has been already rollbacked and could work incorrectly\n/
           ).to_stderr
         end
       end
@@ -83,7 +83,7 @@ describe TestProf::BeforeAll::Adapters::ActiveRecord do
 
         it "warns when connection does not have open transaction" do
           expect { subject }.to output(
-            "!!! before_all transaction has been already rollbacked and could work incorrectly\n"
+            /!!! before_all transaction has been already rollbacked and could work incorrectly\n/
           ).to_stderr
         end
       end

--- a/spec/test_prof/memory_prof/minitest_spec.rb
+++ b/spec/test_prof/memory_prof/minitest_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_prof/memory_prof/minitest"
+
+describe Minitest::TestProf::MemoryProfReporter do
+  subject { described_class.new }
+
+  let(:tracker) { subject.tracker }
+  let(:printer) { subject.printer }
+
+  before do
+    allow(tracker).to receive(:start)
+    allow(tracker).to receive(:finish)
+    allow(tracker).to receive(:example_started)
+    allow(tracker).to receive(:example_finished)
+    allow(tracker).to receive(:group_started)
+    allow(tracker).to receive(:group_finished)
+
+    allow(printer).to receive(:print)
+
+    allow(subject).to receive(:location_with_line_number).and_return("./test/models/reports.rb:57")
+  end
+
+  describe "#prerecord" do
+    it "tracks the start of an example" do
+      subject.prerecord("Report", "test_prepare")
+
+      expect(tracker).to have_received(:example_started).with({
+        name: "prepare",
+        location: "./test/models/reports.rb:57"
+      })
+    end
+  end
+
+  describe "#record" do
+    it "tracks the start of an example" do
+      subject.prerecord("Report", "test_prepare")
+      subject.record(nil)
+
+      expect(tracker).to have_received(:example_started).with({
+        name: "prepare",
+        location: "./test/models/reports.rb:57"
+      })
+    end
+  end
+
+  describe "#start" do
+    it "starts the tracking process" do
+      subject.start
+
+      expect(tracker).to have_received(:start)
+    end
+  end
+
+  describe "#report" do
+    it "finishes the tracking process" do
+      subject.report
+
+      expect(tracker).to have_received(:finish)
+    end
+
+    it "prints the results" do
+      subject.report
+
+      expect(printer).to have_received(:print)
+    end
+  end
+end

--- a/spec/test_prof/memory_prof/printer/number_to_human_spec.rb
+++ b/spec/test_prof/memory_prof/printer/number_to_human_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe TestProf::MemoryProf::Printer::NumberToHuman do
+  subject { described_class }
+
+  describe "#convert" do
+    let(:convert) { subject.convert(number) }
+
+    context "when number is 0" do
+      let(:number) { 0 }
+
+      it "returns 0B" do
+        expect(convert).to eq("0B")
+      end
+    end
+
+    context "when number < 1KB" do
+      let(:number) { 700 }
+
+      it "returns the value in bytes" do
+        expect(convert).to eq("700B")
+      end
+    end
+
+    context "when number > 1024 ZB" do
+      let(:number) { 7 * 2**80 }
+
+      it "returns the value in ZB" do
+        expect(convert).to eq("7168ZB")
+      end
+    end
+
+    context "when number can be converted to an integer" do
+      let(:number) { 7 * 2**20 }
+
+      it "returns the value as an integer" do
+        expect(convert).to eq("7MB")
+      end
+    end
+
+    context "when number can not be converted to an integer" do
+      let(:number) { 7 * 2**20 + 550 * 2**10 }
+
+      it "rounds the value to two digits" do
+        expect(convert).to eq("7.54MB")
+      end
+    end
+  end
+end

--- a/spec/test_prof/memory_prof/printer_spec.rb
+++ b/spec/test_prof/memory_prof/printer_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+shared_examples "TestProf::MemoryProf::Printer" do
+  subject { described_class.new(tracker) }
+
+  let(:tracker) do
+    instance_double(
+      TestProf::MemoryProf::Tracker,
+      top_count: 3,
+      total_memory: 500,
+      groups: groups,
+      examples: examples
+    )
+  end
+
+  let(:groups) do
+    [
+      {name: "AnswersController", location: "./spec/controllers/answers_controller_spec.rb:3", memory: 200},
+      {name: "#publish", location: "./spec/nodels/question_spec.rb:179", memory: 100},
+      {name: "when email and name are present", location: "./spec/lib/import_spec.rb:34", memory: 50}
+    ]
+  end
+
+  let(:examples) do
+    [
+      {name: "returns nil", location: "./spec/models/reports_spec.rb:57", memory: 75},
+      {name: "searches users by email", location: "./spec/searches/users_search_spec.rb:15", memory: 50},
+      {name: "calculates the average number of answers", location: "./spec/lib/stats_spec.rb:44", memory: 25}
+    ]
+  end
+
+  before do
+    allow(subject).to receive(:log)
+  end
+end
+
+describe TestProf::MemoryProf::AllocPrinter do
+  include_examples "TestProf::MemoryProf::Printer"
+
+  describe "#print" do
+    let(:print) { subject.print }
+
+    context "and there are both groups and examples" do
+      let(:message) do
+        <<~MESSAGE
+          MemoryProf results
+          
+          Total allocations: 500
+          
+          Top 3 groups (by allocations):
+          
+          AnswersController (./spec/controllers/answers_controller_spec.rb:3) – +200 (40.0%)
+          #publish (./spec/nodels/question_spec.rb:179) – +100 (20.0%)
+          when email an...me are present (./spec/lib/import_spec.rb:34) – +50 (10.0%)
+          
+          Top 3 examples (by allocations):
+          
+          returns nil (./spec/models/reports_spec.rb:57) – +75 (15.0%)
+          searches users by email (./spec/searches/users_search_spec.rb:15) – +50 (10.0%)
+          calculates th...ber of answers (./spec/lib/stats_spec.rb:44) – +25 (5.0%)
+
+        MESSAGE
+      end
+
+      it "prints results for groups and examples" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+
+    context "and there are no examples" do
+      let(:examples) { [] }
+
+      let(:message) {
+        <<~MESSAGE
+          MemoryProf results
+          
+          Total allocations: 500
+        
+          Top 3 groups (by allocations):
+        
+          AnswersController (./spec/controllers/answers_controller_spec.rb:3) – +200 (40.0%)
+          #publish (./spec/nodels/question_spec.rb:179) – +100 (20.0%)
+          when email an...me are present (./spec/lib/import_spec.rb:34) – +50 (10.0%)
+
+        MESSAGE
+      }
+
+      it "prints results for groups only" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+
+    context "and there are no groups" do
+      let(:groups) { [] }
+
+      let(:message) {
+        <<~MESSAGE
+          MemoryProf results
+          
+          Total allocations: 500
+        
+          Top 3 examples (by allocations):
+        
+          returns nil (./spec/models/reports_spec.rb:57) – +75 (15.0%)
+          searches users by email (./spec/searches/users_search_spec.rb:15) – +50 (10.0%)
+          calculates th...ber of answers (./spec/lib/stats_spec.rb:44) – +25 (5.0%)
+
+        MESSAGE
+      }
+
+      it "prints results for examples only" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+
+    context "and there are no groups or examples" do
+      let(:groups) { [] }
+      let(:examples) { [] }
+
+      let(:message) {
+        <<~MESSAGE
+          MemoryProf results
+          
+          Total allocations: 500
+
+        MESSAGE
+      }
+
+      it "prints results for examples only" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+  end
+end
+
+describe TestProf::MemoryProf::RssPrinter do
+  include_examples "TestProf::MemoryProf::Printer"
+
+  describe "#print" do
+    let(:print) { subject.print }
+
+    context "and there are both groups and examples" do
+      let(:message) do
+        <<~MESSAGE
+          MemoryProf results
+          
+          Final RSS: 500B
+          
+          Top 3 groups (by RSS):
+          
+          AnswersController (./spec/controllers/answers_controller_spec.rb:3) – +200B (40.0%)
+          #publish (./spec/nodels/question_spec.rb:179) – +100B (20.0%)
+          when email an...me are present (./spec/lib/import_spec.rb:34) – +50B (10.0%)
+          
+          Top 3 examples (by RSS):
+          
+          returns nil (./spec/models/reports_spec.rb:57) – +75B (15.0%)
+          searches users by email (./spec/searches/users_search_spec.rb:15) – +50B (10.0%)
+          calculates th...ber of answers (./spec/lib/stats_spec.rb:44) – +25B (5.0%)
+
+        MESSAGE
+      end
+
+      it "prints results for groups and examples" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+
+    context "and there are no examples" do
+      let(:examples) { [] }
+
+      let(:message) {
+        <<~MESSAGE
+          MemoryProf results
+          
+          Final RSS: 500B
+        
+          Top 3 groups (by RSS):
+        
+          AnswersController (./spec/controllers/answers_controller_spec.rb:3) – +200B (40.0%)
+          #publish (./spec/nodels/question_spec.rb:179) – +100B (20.0%)
+          when email an...me are present (./spec/lib/import_spec.rb:34) – +50B (10.0%)
+
+        MESSAGE
+      }
+
+      it "prints results for groups only" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+
+    context "and there are no groups" do
+      let(:groups) { [] }
+
+      let(:message) {
+        <<~MESSAGE
+          MemoryProf results
+          
+          Final RSS: 500B
+        
+          Top 3 examples (by RSS):
+        
+          returns nil (./spec/models/reports_spec.rb:57) – +75B (15.0%)
+          searches users by email (./spec/searches/users_search_spec.rb:15) – +50B (10.0%)
+          calculates th...ber of answers (./spec/lib/stats_spec.rb:44) – +25B (5.0%)
+
+        MESSAGE
+      }
+
+      it "prints results for examples only" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+
+    context "and there are no groups or examples" do
+      let(:groups) { [] }
+      let(:examples) { [] }
+
+      let(:message) {
+        <<~MESSAGE
+          MemoryProf results
+          
+          Final RSS: 500B
+
+        MESSAGE
+      }
+
+      it "prints results for examples only" do
+        print
+
+        expect(subject).to have_received(:log).with(:info, message)
+      end
+    end
+  end
+end

--- a/spec/test_prof/memory_prof/rspec_spec.rb
+++ b/spec/test_prof/memory_prof/rspec_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "test_prof/memory_prof/rspec"
+
+describe TestProf::MemoryProf::RSpecListener do
+  subject { described_class.new }
+
+  let(:tracker) { subject.tracker }
+  let(:printer) { subject.printer }
+
+  let(:example) do
+    instance_double(
+      RSpec::Core::Example,
+      description: "returns nil",
+      metadata: {location: "./spec/models/reports_spec.rb:57"}
+    )
+  end
+
+  let(:group) do
+    double(
+      RSpec::Core::ExampleGroup,
+      description: "#publish",
+      metadata: {location: "./spec/nodels/question_spec.rb:179"}
+    )
+  end
+
+  before do
+    tracker = instance_double(
+      TestProf::MemoryProf::Tracker,
+      start: nil,
+      finish: nil,
+      example_started: nil,
+      example_finished: nil,
+      group_started: nil,
+      group_finished: nil
+    )
+
+    allow(TestProf::MemoryProf).to receive(:tracker).and_return(tracker)
+    allow(printer).to receive(:print)
+  end
+
+  xdescribe "#initialize" do
+    it "starts the tracking process" do
+      subject
+
+      expect(tracker).to have_received(:start)
+    end
+  end
+
+  describe "#example_started" do
+    let(:notification) do
+      RSpec::Core::Notifications::ExampleNotification.send(:new, example)
+    end
+
+    it "tracks the start of an example" do
+      subject.example_started(notification)
+
+      expect(tracker).to have_received(:example_started).with({
+        name: "returns nil",
+        location: "./spec/models/reports_spec.rb:57"
+      })
+    end
+  end
+
+  describe "#example_finished" do
+    let(:notification) do
+      RSpec::Core::Notifications::ExampleNotification.send(:new, example)
+    end
+
+    it "tracks the end of an example" do
+      subject.example_finished(notification)
+
+      expect(tracker).to have_received(:example_finished).with({
+        name: "returns nil",
+        location: "./spec/models/reports_spec.rb:57"
+      })
+    end
+  end
+
+  describe "#example_group_started" do
+    let(:notification) do
+      RSpec::Core::Notifications::GroupNotification.send(:new, group)
+    end
+
+    it "tracks the end of an example" do
+      subject.example_group_started(notification)
+
+      expect(tracker).to have_received(:group_started).with({
+        name: "#publish",
+        location: "./spec/nodels/question_spec.rb:179"
+      })
+    end
+  end
+
+  describe "#example_group_finished" do
+    let(:notification) do
+      RSpec::Core::Notifications::GroupNotification.send(:new, group)
+    end
+
+    it "tracks the end of an example" do
+      subject.example_group_finished(notification)
+
+      expect(tracker).to have_received(:group_finished).with({
+        name: "#publish",
+        location: "./spec/nodels/question_spec.rb:179"
+      })
+    end
+  end
+
+  describe "#report" do
+    it "finishes the tracking process" do
+      subject.report
+
+      expect(tracker).to have_received(:finish)
+    end
+
+    it "prints the results" do
+      subject.report
+
+      expect(printer).to have_received(:print)
+    end
+  end
+end

--- a/spec/test_prof/memory_prof/tracker/linked_list_spec.rb
+++ b/spec/test_prof/memory_prof/tracker/linked_list_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+describe TestProf::MemoryProf::Tracker::LinkedList do
+  subject { described_class.new(100) }
+
+  it "initializes a head node" do
+    expect(subject.head).to have_attributes(item: :total, previous: nil, memory_at_start: 100)
+  end
+
+  describe "#add_node" do
+    let(:add_node) { subject.add_node(:item, 200) }
+
+    it "add a new node to the beginning of the list" do
+      previous = subject.head
+      add_node
+
+      expect(subject.head).to have_attributes(item: :item, previous: previous, memory_at_start: 200)
+    end
+  end
+
+  describe "#remove_node" do
+    let(:remove_node) { subject.remove_node(:item, 300) }
+
+    before do
+      subject.add_node(:item, 200)
+      allow(subject.head).to receive(:finish)
+    end
+
+    it "finishes the current head node" do
+      current = subject.head
+      remove_node
+
+      expect(current).to have_received(:finish).with(300)
+    end
+
+    it "moves the head to the previous node" do
+      previous = subject.head.previous
+      remove_node
+
+      expect(subject.head).to eq(previous)
+    end
+
+    it "return the current head node" do
+      current = subject.head
+
+      expect(remove_node).to eq(current)
+    end
+  end
+end
+
+describe TestProf::MemoryProf::Tracker::LinkedListNode do
+  subject do
+    described_class.new(
+      item: :item,
+      memory_at_start: 100,
+      previous: previous
+    )
+  end
+
+  let(:previous) { nil }
+
+  describe "#total_memory" do
+    before do
+      subject.instance_variable_set("@memory_at_start", memory_at_start)
+      subject.instance_variable_set("@memory_at_finish", memory_at_finish)
+    end
+
+    context "when memory_at_finish is nil" do
+      let(:memory_at_start) { 100 }
+      let(:memory_at_finish) { nil }
+
+      it "returns 0" do
+        expect(subject.total_memory).to eq(0)
+      end
+    end
+
+    context "when memory_at_start > memory_at_finish" do
+      let(:memory_at_start) { 200 }
+      let(:memory_at_finish) { 100 }
+
+      it "returns 0" do
+        expect(subject.total_memory).to eq(0)
+      end
+    end
+
+    context "when memory_at_start < memory_at_finish" do
+      let(:memory_at_start) { 100 }
+      let(:memory_at_finish) { 200 }
+
+      it "calculates the difference between memory_at_finish and memory_at_start" do
+        expect(subject.total_memory).to eq(100)
+      end
+    end
+  end
+
+  describe "#hooks_memory" do
+    before do
+      subject.instance_variable_set("@memory_at_start", 100)
+      subject.instance_variable_set("@memory_at_finish", 200)
+      subject.instance_variable_set("@nested_memory", 50)
+    end
+
+    it "calculates the difference between total_memory and nested_memory" do
+      expect(subject.hooks_memory).to eq(50)
+    end
+  end
+
+  describe "#finish" do
+    let(:finish) { subject.finish(200) }
+
+    context "when previous node exists" do
+      let(:previous) do
+        described_class.new(
+          item: :previous,
+          memory_at_start: 50,
+          previous: nil
+        )
+      end
+
+      it "sets memory_at_finish" do
+        finish
+
+        expect(subject.memory_at_finish).to eq(200)
+      end
+
+      it "updates previous.nested_memory" do
+        finish
+
+        expect(previous.nested_memory).to eq(100)
+      end
+    end
+
+    context "when previous node does not exist" do
+      let(:previous) { nil }
+
+      it "sets memory_at_finish" do
+        finish
+
+        expect(subject.memory_at_finish).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/test_prof/memory_prof/tracker/rss_tool_spec.rb
+++ b/spec/test_prof/memory_prof/tracker/rss_tool_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+describe TestProf::MemoryProf::Tracker::RssTool do
+  subject { described_class }
+
+  describe ".tool" do
+    before do
+      allow(subject).to receive(:os_type).and_return(os_type)
+    end
+
+    context "when an OS is supported" do
+      let(:os_type) { :macosx }
+
+      it "returns an rss tool" do
+        expect(subject.tool).to be_kind_of(subject::PS)
+      end
+    end
+
+    context "when an OS is not supported" do
+      let(:os_type) { :invalid }
+
+      it "returns nil" do
+        expect(subject.tool).to eq(nil)
+      end
+    end
+  end
+
+  describe ".os_type" do
+    before do
+      @original_os = RbConfig::CONFIG["host_os"]
+      RbConfig::CONFIG["host_os"] = host_os
+    end
+
+    after do
+      RbConfig::CONFIG["host_os"] = @original_os
+    end
+
+    context "when the host OS is Linux" do
+      let(:host_os) { "linux" }
+
+      it "returns :linux" do
+        expect(subject.os_type).to eq(:linux)
+      end
+    end
+
+    context "when the host OS is macOS" do
+      let(:host_os) { "darwin22" }
+
+      it "returns :macosx" do
+        expect(subject.os_type).to eq(:macosx)
+      end
+    end
+
+    context "when the host OS is macOS" do
+      let(:host_os) { "mac os 14" }
+
+      it "returns :macosx" do
+        expect(subject.os_type).to eq(:macosx)
+      end
+    end
+
+    %w[solaris bsd].each do |os|
+      context "when the host OS is #{os}" do
+        let(:host_os) { "#{os} 17" }
+
+        it "returns :unix" do
+          expect(subject.os_type).to eq(:unix)
+        end
+      end
+    end
+
+    context "when the host OS is Windows" do
+      let(:host_os) { "mswin" }
+
+      it "returns :windows" do
+        expect(subject.os_type).to eq(:windows)
+      end
+    end
+  end
+end
+
+describe TestProf::MemoryProf::Tracker::RssTool::ProcFS do
+  subject { described_class.new }
+
+  describe "#track" do
+    before do
+      io = instance_double(IO, seek: nil, gets: "46441 196384 1804 1 0 24133 0\n")
+
+      allow(File).to receive(:open).and_return(io)
+      subject.instance_variable_set("@page_size", 1024)
+    end
+
+    it "retrieves rss via proc statm" do
+      subject.track
+
+      expect(File).to have_received(:open).with(/\/proc\/\d+\/statm/, "r")
+    end
+
+    it "returns the current rss" do
+      expect(subject.track).to eq(201097216)
+    end
+  end
+end
+
+describe TestProf::MemoryProf::Tracker::RssTool::PS do
+  subject { described_class.new }
+
+  describe "#track" do
+    before do
+      allow(subject).to receive(:`).and_return("   RSS\n196384")
+    end
+
+    it "retrieves rss via ps" do
+      subject.track
+
+      expect(subject).to have_received(:`).with(/ps -o rss -p \d+/)
+    end
+
+    it "returns the current rss" do
+      expect(subject.track).to eq(201097216)
+    end
+  end
+end
+
+describe TestProf::MemoryProf::Tracker::RssTool::GetProcess do
+  subject { described_class.new }
+
+  describe "#track" do
+    before do
+      allow(subject).to receive(:`).and_return("\n      WS\n      --\n201097216\n\n\n")
+    end
+
+    it "retrieves rss via Get-Process" do
+      subject.track
+
+      expect(subject).to have_received(:`).with(/powershell -Command "Get-Process -Id \d+ | select WS"/)
+    end
+
+    it "returns the current rss" do
+      expect(subject.track).to eq(201097216)
+    end
+  end
+end

--- a/spec/test_prof/memory_prof/tracker_spec.rb
+++ b/spec/test_prof/memory_prof/tracker_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+shared_examples "TestProf::MemoryProf::Tracker" do
+  let(:list) { TestProf::MemoryProf::Tracker::LinkedList.new(100) }
+
+  describe "#start" do
+    it "initializes a linked list" do
+      subject.start
+
+      expect(subject.list).to be_kind_of(TestProf::MemoryProf::Tracker::LinkedList)
+    end
+  end
+
+  describe "#finish" do
+    before do
+      allow(subject).to receive(:track).and_return(200)
+      allow(subject).to receive(:list).and_return(list)
+    end
+
+    it "sets total_memory" do
+      subject.finish
+
+      expect(subject.total_memory).to eq(100)
+    end
+  end
+
+  describe "#example_started" do
+    let(:example_started) { subject.example_started({name: :example}) }
+
+    before do
+      allow(subject).to receive(:track).and_return(200)
+      allow(subject).to receive(:list).and_return(list)
+    end
+
+    it "tracks memory at the start of an example" do
+      example_started
+
+      expect(subject.list.head).to have_attributes(item: {name: :example}, memory_at_start: 200)
+    end
+  end
+
+  describe "#example_finished" do
+    let(:example_finished) { subject.example_finished({name: :example}) }
+
+    before do
+      list.add_node({name: :example}, 200)
+
+      allow(subject).to receive(:track).and_return(350)
+      allow(subject).to receive(:list).and_return(list)
+    end
+
+    context "when the example memory > the memory of the top examples" do
+      before do
+        [75, 100, 125, 175, 200].each do |memory|
+          subject.examples << {memory: memory}
+        end
+      end
+
+      it "adds the example to the top examples" do
+        example_finished
+
+        expect(subject.examples).to match_array([
+          {memory: 200},
+          {memory: 175},
+          {name: :example, memory: 150},
+          {memory: 125},
+          {memory: 100}
+        ])
+      end
+    end
+
+    context "when the example memory <= the memory of the top examples" do
+      before do
+        [175, 200, 225, 250, 275].each do |memory|
+          subject.examples << {memory: memory}
+        end
+      end
+
+      it "adds the example to the top examples" do
+        example_finished
+
+        expect(subject.examples).to match_array([
+          {memory: 275},
+          {memory: 250},
+          {memory: 225},
+          {memory: 200},
+          {memory: 175}
+        ])
+      end
+    end
+  end
+
+  describe "#group_started" do
+    let(:group_started) { subject.group_started({name: :group}) }
+
+    before do
+      allow(subject).to receive(:track).and_return(200)
+      allow(subject).to receive(:list).and_return(list)
+    end
+
+    it "tracks memory at the start of a group" do
+      group_started
+
+      expect(subject.list.head).to have_attributes(item: {name: :group}, memory_at_start: 200)
+    end
+  end
+
+  describe "#group_finished" do
+    let(:group_finished) { subject.group_finished({name: :group}) }
+
+    before do
+      list.add_node({name: :group}, 200)
+
+      allow(subject).to receive(:track).and_return(350)
+      allow(subject).to receive(:list).and_return(list)
+    end
+
+    context "when the group memory > the memory of the top groups" do
+      before do
+        [75, 100, 125, 175, 200].each do |memory|
+          subject.groups << {memory: memory}
+        end
+      end
+
+      it "adds the group to the top groups" do
+        group_finished
+
+        expect(subject.groups).to match_array([
+          {memory: 200},
+          {memory: 175},
+          {name: :group, memory: 150},
+          {memory: 125},
+          {memory: 100}
+        ])
+      end
+    end
+
+    context "when the group memory <= the memory of the top groups" do
+      before do
+        [175, 200, 225, 250, 275].each do |memory|
+          subject.groups << {memory: memory}
+        end
+      end
+
+      it "adds the group to the top groups" do
+        group_finished
+
+        expect(subject.groups).to match_array([
+          {memory: 275},
+          {memory: 250},
+          {memory: 225},
+          {memory: 200},
+          {memory: 175}
+        ])
+      end
+    end
+  end
+end
+
+describe TestProf::MemoryProf::AllocTracker do
+  subject { described_class.new(5) }
+
+  if RUBY_ENGINE == "jruby"
+    it "raises an error" do
+      expect { subject }.to raise_error("Your Ruby Engine or OS is not supported")
+    end
+  else
+    it_behaves_like "TestProf::MemoryProf::Tracker"
+
+    describe "#track" do
+      before do
+        allow(GC).to receive(:stat).and_return({total_allocated_objects: 100})
+      end
+
+      it "returns the current number of allocations" do
+        expect(subject.track).to eq(100)
+      end
+    end
+
+    describe "#supported?" do
+      it "returns true" do
+        expect(subject.supported?).to be_truthy
+      end
+    end
+  end
+end
+
+describe TestProf::MemoryProf::RssTracker do
+  subject { described_class.new(5) }
+
+  let(:tool) { instance_double(TestProf::MemoryProf::Tracker::RssTool::PS, track: 100) }
+
+  before do
+    allow(TestProf::MemoryProf::Tracker::RssTool).to receive(:tool).and_return(tool)
+  end
+
+  it_behaves_like "TestProf::MemoryProf::Tracker"
+
+  describe "#track" do
+    it "returns the current rss" do
+      expect(subject.track).to eq(100)
+    end
+  end
+
+  describe "#supported?" do
+    context "when the host OS is supported" do
+      it "returns true" do
+        expect(subject.supported?).to be_truthy
+      end
+    end
+
+    context "when the host OS is not supported" do
+      let(:tool) { nil }
+
+      it "raises an error" do
+        expect { subject }.to raise_error("Your Ruby Engine or OS is not supported")
+      end
+    end
+  end
+end

--- a/spec/test_prof/memory_prof_spec.rb
+++ b/spec/test_prof/memory_prof_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+describe TestProf::MemoryProf do
+  subject { described_class }
+
+  describe ".config" do
+    let(:config) { subject.config }
+
+    it "returns an instance of TestProf::MemoryProf::Configuration" do
+      expect(config).to be_kind_of(TestProf::MemoryProf::Configuration)
+    end
+
+    describe "#mode=" do
+      let(:set_mode) { config.mode = value }
+
+      context "when value is alloc" do
+        let(:value) { "alloc" }
+
+        it "sets mode to alloc" do
+          set_mode
+
+          expect(config.mode).to eq(:alloc)
+        end
+      end
+
+      context "when value is rss" do
+        let(:value) { "rss" }
+
+        it "sets mode to rss" do
+          set_mode
+
+          expect(config.mode).to eq(:rss)
+        end
+      end
+
+      context "when value is neither alloc or rss" do
+        let(:value) { "invalid" }
+
+        it "sets mode to alloc" do
+          set_mode
+
+          expect(config.mode).to eq(:rss)
+        end
+      end
+    end
+
+    describe "#top_count=" do
+      let(:set_top_count) { config.top_count = value }
+
+      context "when value is an integer" do
+        let(:value) { 5 }
+
+        it "sets top_count to the value" do
+          set_top_count
+
+          expect(config.top_count).to eq(5)
+        end
+      end
+
+      context "when value is a float" do
+        let(:value) { 5.7 }
+
+        it "transforms the value to an integer" do
+          set_top_count
+
+          expect(config.top_count).to eq(5)
+        end
+      end
+
+      context "when value is 0" do
+        let(:value) { 0 }
+
+        it "sets top_count to 5" do
+          set_top_count
+
+          expect(config.top_count).to eq(5)
+        end
+      end
+
+      context "when value is negative" do
+        let(:value) { -7 }
+
+        it "sets top_count to 5" do
+          set_top_count
+
+          expect(config.top_count).to eq(5)
+        end
+      end
+
+      context "when value is nil" do
+        let(:value) { nil }
+
+        it "sets top_count to 5" do
+          set_top_count
+
+          expect(config.top_count).to eq(5)
+        end
+      end
+
+      context "when value is a text" do
+        let(:value) { "invalid" }
+
+        it "sets top_count to 5" do
+          set_top_count
+
+          expect(config.top_count).to eq(5)
+        end
+      end
+    end
+  end
+
+  describe ".tracker" do
+    let(:tracker) { subject.tracker }
+
+    context "when mode is alloc" do
+      before { described_class.config.mode = "alloc" }
+
+      if RUBY_ENGINE == "jruby"
+        it "raises an error" do
+          expect { tracker }.to raise_error("Your Ruby Engine or OS is not supported")
+        end
+      else
+        it "returns an instance of AllocTracker" do
+          expect(tracker).to be_kind_of(TestProf::MemoryProf::AllocTracker)
+        end
+
+        it "sets tracker.top_count to config.top_count" do
+          expect(tracker.top_count).to eq(5)
+        end
+      end
+    end
+
+    context "when mode is rss" do
+      before { described_class.config.mode = "rss" }
+
+      it "returns an instance of RssTracker" do
+        expect(tracker).to be_kind_of(TestProf::MemoryProf::RssTracker)
+      end
+
+      it "sets tracker.top_count to config.top_count" do
+        expect(tracker.top_count).to eq(5)
+      end
+    end
+  end
+
+  describe ".printer" do
+    let(:printer) { subject.printer(tracker) }
+    let(:tracker) { subject.tracker }
+
+    context "when mode is alloc" do
+      before { described_class.config.mode = "alloc" }
+
+      if RUBY_ENGINE == "jruby"
+        it "raises an error" do
+          expect { printer }.to raise_error("Your Ruby Engine or OS is not supported")
+        end
+      else
+        it "returns an instance of AllocPrinter" do
+          expect(printer).to be_kind_of(TestProf::MemoryProf::AllocPrinter)
+        end
+
+        it "sets printer.tracker" do
+          expect(printer.send(:tracker)).to eq(tracker)
+        end
+      end
+    end
+
+    context "when mode is rss" do
+      before { described_class.config.mode = "rss" }
+
+      it "returns an instance of RssPrinter" do
+        expect(printer).to be_kind_of(TestProf::MemoryProf::RssPrinter)
+      end
+
+      it "sets printer.tracker" do
+        expect(printer.send(:tracker)).to eq(tracker)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is the purpose of this pull request?

Introducing a memory profiler `MemoryProf` that can help to detect test examples and groups that cause memory spikes. Memory profiling supports two metrics: RSS and allocations.
 
Examples:
```sh
TEST_MEM_PROF='rss' rspec ...
TEST_MEM_PROF='alloc' rspec ...
```

By default MemoryProf shows the top 5 examples and groups (for RSpec) but you can set how many items to display with:
```sh
 TEST_MEM_PROF='rss' TEST_MEM_PROF_COUNT=10 rspec ...
```

The examples block shows the amount of memory used by each example, and the groups block displays the memory allocated by other code defined in the groups. For example, RSpec groups may include heavy `before(:all)` (or `before_all`) setup blocks, so it is helpful to see which groups use the most amount of memory outside of their examples.

### What changes did you make? (overview)

`MemoryProf` has the following structure:

1. Configuration defines MemoryProf configs and adds a few supporting methods ([memory_prof.rb](https://github.com/Vankiru/test-prof/blob/feature/memory-prof/lib/test_prof/memory_prof.rb)).
2. Trackers are responsible for tracking memory usage and determining the top n examples and groups ([memory_prof/tracker.rb](https://github.com/Vankiru/test-prof/blob/feature/memory-prof/lib/test_prof/memory_prof/tracker.rb)).
3. Printer assembles and prints the results of a tracker ([memory_prof/printer.rb](https://github.com/Vankiru/test-prof/blob/feature/memory-prof/lib/test_prof/memory_prof/printer.rb)).
4. RSpec integration ([memory_prof/rspec.rb](https://github.com/Vankiru/test-prof/blob/feature/memory-prof/lib/test_prof/memory_prof/rspec.rb)).
5. Minitest integration ([memory_prof/minitest.rb](https://github.com/Vankiru/test-prof/blob/feature/memory-prof/lib/test_prof/memory_prof/minitest.rb)).

There are two types of trackers: `AllocTracker` and `RssTracker`. A tracker consists of four main parts:
* `list` - a linked list that is used to track memory for individual groups/examples, and it is an instance of `LinkedList `(for more info see ([memory_prof/tracker/linked_list.rb](https://github.com/Vankiru/test-prof/blob/feature/memory-prof/lib/test_prof/memory_prof/tracker/linked_list.rb)).
* `examples` – the top n examples, an instance of `Utils::SizedOrderedSet`.
* `groups` – the top n groups, an instance of `Utils::SizedOrderedSet`.
* `track` - a method that fetches the amount of memory in use at a certain point.

### Checklist
 
- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [x] I've updated a documentation